### PR TITLE
Updated the bounding volume hierarchy creation

### DIFF
--- a/2021.01/CS500/Shape.cpp
+++ b/2021.01/CS500/Shape.cpp
@@ -423,7 +423,7 @@ void Model::bounding_box()
 
 void Model::makeBoundingHierarchy(const vector<Shape*>& shapes)
 {
-  Tree = Eigen::KdBVH<float, 3, Shape*>(shapes.begin(), shapes.end());
+  Tree.init(shapes.begin(), shapes.end());
 }
 
 glm::vec3 Model::centroidOfTri(const vec3& tri)


### PR DESCRIPTION
It was performing an unnecessary copy, this method of using init should allow for a nearly invisible performance increase.